### PR TITLE
feat: Agrega función para calcular promedio y pruebas

### DIFF
--- a/calculadora/promedio.py
+++ b/calculadora/promedio.py
@@ -1,0 +1,17 @@
+def calcular_promedio(numeros):
+  """
+  Calcula el promedio de una lista de números.
+
+  Args:
+    numeros: Una lista de números (enteros o flotantes).
+
+  Returns:
+    El promedio de los números en la lista.
+
+  Raises:
+    ValueError: Si la lista de entrada está vacía.
+  """
+  if not numeros:
+    raise ValueError("La lista no puede estar vacía.")
+
+  return sum(numeros) / len(numeros)

--- a/tests/test_promedio.py
+++ b/tests/test_promedio.py
@@ -1,0 +1,34 @@
+import unittest
+import sys
+import os
+
+# Agrega el directorio padre a la ruta para encontrar el módulo 'calculadora'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from calculadora.promedio import calcular_promedio
+
+class TestPromedio(unittest.TestCase):
+
+    def test_promedio_lista_tipica(self):
+        """Prueba el promedio de una lista de enteros positivos."""
+        self.assertEqual(calcular_promedio([1, 2, 3, 4, 5]), 3.0)
+
+    def test_promedio_con_negativos(self):
+        """Prueba el promedio de una lista con números negativos."""
+        self.assertEqual(calcular_promedio([-1, 1, -2, 2, 0]), 0)
+
+    def test_promedio_con_flotantes(self):
+        """Prueba el promedio de una lista de números de punto flotante."""
+        self.assertAlmostEqual(calcular_promedio([1.5, 2.5, 3.5]), 2.5)
+
+    def test_promedio_lista_un_elemento(self):
+        """Prueba el promedio de una lista con un solo elemento."""
+        self.assertEqual(calcular_promedio([10]), 10.0)
+
+    def test_promedio_lista_vacia(self):
+        """Prueba que una lista vacía arroja un ValueError."""
+        with self.assertRaises(ValueError):
+            calcular_promedio([])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Se agrega una función `calcular_promedio` en `calculadora/promedio.py` que calcula el promedio de una lista de números.

- La función maneja listas de enteros, flotantes y números negativos.
- Arroja un `ValueError` si la lista de entrada está vacía.

Se incluyen pruebas unitarias en `tests/test_promedio.py` para verificar la funcionalidad correcta, cubriendo varios casos de uso y casos límite.